### PR TITLE
alterado metadata para texto do material de divulgacao

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <meta property="og:type" content="website" />
     <meta
       property="og:description"
-      content="Mauá Reservation, a nova forma de reservar salas, laboratórios e quadras no Instituto Mauá de Tecnologia!"
+      content="Mauá Reservation, a nova forma de reservar as quadras e campo do CEAF."
     />
     <meta
       property="og:image"


### PR DESCRIPTION
Fiz a alteração do texto de descrição do metadado que aparece ao colar o link em alguma caixa de texto compatível (email, teams, whatsapp) para conformidade com o material de divulgação.